### PR TITLE
issue-14 deploy.sh works in test/debug mode by default

### DIFF
--- a/deployment-scripts/deploy.sh
+++ b/deployment-scripts/deploy.sh
@@ -5,6 +5,8 @@ function usage {
 Usage: ${0} BASE_DIR ENV
 Deploys to the ENV environment.
 BASE_DIR is the base folder containing the configurations for all environments
+
+If environment variable TEST is defined, ${0} works in test/debug mode and prints out the output from kustomize
 EOF
 }
 
@@ -22,7 +24,6 @@ fi
 
 export BASE_DIR=$1
 export KUBE_NAMESPACE=$2
-export TEST=$3
 
 set -euo pipefail
 # automatically export all environment variables

--- a/tests/deploy.sh
+++ b/tests/deploy.sh
@@ -3,7 +3,7 @@
 
 @test "Test deploy with a dummy environment" {
   cd /tests
-  ACTUAL=$(deploy.sh deploy-dummy cdp-dev test)
+  ACTUAL=$(TEST=1 deploy.sh deploy-dummy cdp-dev)
   EXPECTED=$(cat deploy.expected)
   DIFF=$(diff <(echo "$ACTUAL" ) <(echo "$EXPECTED"))
 


### PR DESCRIPTION
line 25 defines TEST, even if it's empty
So in the test on line 80 testing whether or not TEST is defined `if [[ -z "${TEST+x}" ]]; then` the else block is always executed
Therefore removing the `export TEST=$3` line