### PR TITLE
CDMP-2406 fix broken deploy step (only wait for deployments to complete)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine as build
 
-ENV KUBECTL_VERSION=1.12.3
+ENV KUBECTL_VERSION=1.14.1
 
 RUN apk upgrade -q --no-cache
 RUN apk add -q --no-cache \

--- a/deployment-scripts/run-operation.sh
+++ b/deployment-scripts/run-operation.sh
@@ -97,13 +97,13 @@ if [[ -z "${TEST+x}" ]]; then
   # TEST is undefined so run a proper deployment or performance test
   echo "Beginning deployment to ${KUBE_NAMESPACE}."
 
-  kustomize build ${ENV_OPERATION_BASE_DIR}| envsubst | ${kubectl} apply -f - 
+  kustomize build ${ENV_OPERATION_BASE_DIR} | envsubst | ${kubectl} apply -f - 
   
   
   if [[ $OPERATION == "deploy" ]]; then
    echo "All resources updated."
 
-    kustomize build ${ENV_OPERATION_BASE_DIR}| envsubst |  ${kubectl} wait --for=condition=Available "--timeout=${DEPLOYMENT_TIMEOUT:-300}s"  -f -
+     ${kubectl} wait --for=condition=Available "--timeout=${DEPLOYMENT_TIMEOUT:-300}s" --all deployments
 
     echo "Complete."
   elif [[ $OPERATION == "test" ]]; then


### PR DESCRIPTION
* update to kubectl v 1.14.1 for the '-all' parameter in 'kubectl wait'
* only wait for deployments (other resources do not have an 'Available' condition)